### PR TITLE
[T02] Research TON API endpoints

### DIFF
--- a/docs/ton-rpc-endpoints.md
+++ b/docs/ton-rpc-endpoints.md
@@ -1,0 +1,65 @@
+# TON RPC endpoints — research notes (T02)
+
+Snapshot of the public TON RPC providers we evaluated for the TPS-tracker
+backend. Picked criteria: free tier sufficient for a few req/s, JSON over
+HTTPS (no GraphQL gymnastics), and clear "list recent transactions / get
+block" endpoints.
+
+## Providers compared
+
+| Provider           | Base URL                              | Auth     | Free tier               | Strengths                                       |
+| ------------------ | ------------------------------------- | -------- | ----------------------- | ----------------------------------------------- |
+| **toncenter v2**   | `https://toncenter.com/api/v2`        | API key¹ | 1 req/s w/o key, more w/ | Closest to raw TON node JSON-RPC. Stable.      |
+| **toncenter v3**   | `https://toncenter.com/api/v3`        | API key¹ | same                    | New REST shape, easier `/transactions` paging. |
+| **TonAPI**         | `https://tonapi.io/v2`                | Bearer²  | 1 req/s, 1k req/day     | Indexed view, decoded jettons / NFTs.          |
+| **dton.io GraphQL**| `https://dton.io/graphql`             | none     | generous                | GraphQL only — heavier client.                 |
+
+¹ get a free key at <https://t.me/tonapibot> (toncenter)
+² get a free key at <https://tonconsole.com>
+
+## Endpoints we'll use for TPS measurement
+
+For "transactions per second" we need block headers + tx counts over a
+short rolling window (last N seconds / blocks). Two viable shapes:
+
+### Option A — toncenter v3 `/blocks`
+
+```
+GET https://toncenter.com/api/v3/blocks?workchain=-1&limit=10
+```
+
+Returns the last N masterchain blocks with `tx_count` per block. Sum
+`tx_count` across the window, divide by elapsed seconds → live TPS.
+
+### Option B — TonAPI `/blockchain/blocks/{block_id}`
+
+```
+GET https://tonapi.io/v2/blockchain/blocks/(-1,8000000000000000,123456)
+```
+
+Higher-level decoded blocks; more bytes per response. Use only if we
+need decoded tx-internals for the dashboard.
+
+### Option C — direct lite-server (`liteclient` over TCP)
+
+Lowest latency (~80ms vs 200-400ms for HTTP), but binary protocol —
+needs `tonlibjson` or pure-JS lite-client. Park as v2 optimisation.
+
+## Sanity probe
+
+`scripts/probe-ton-rpc.js` pings each public endpoint above and reports
+status + latency. Run with:
+
+```
+node scripts/probe-ton-rpc.js
+```
+
+It exits 0 if at least one provider responded healthy (so it can be
+wired into CI as a smoke test), 1 otherwise.
+
+## Recommendation
+
+Start with **toncenter v3** for the MVP — REST shape matches our needs,
+free-tier is enough for a single-page dashboard, and the `tx_count`
+field on `/blocks` directly answers the TPS question without follow-up
+calls. Add **TonAPI** as a fallback when toncenter rate-limits.

--- a/scripts/probe-ton-rpc.js
+++ b/scripts/probe-ton-rpc.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+//
+// probe-ton-rpc.js — connectivity smoke test for the TON RPC providers
+// catalogued in docs/ton-rpc-endpoints.md.
+//
+// Pings each provider's "lightest" endpoint, reports HTTP status +
+// latency, and exits 0 iff at least one provider is healthy. No deps,
+// runs on stock Node 18+ (uses global fetch).
+//
+// Usage:
+//   node scripts/probe-ton-rpc.js
+//   node scripts/probe-ton-rpc.js --json   # machine-readable output
+
+const PROVIDERS = [
+  {
+    name: 'toncenter v3 /blocks',
+    url:  'https://toncenter.com/api/v3/blocks?workchain=-1&limit=1',
+    healthy: (r, body) => r.status === 200 && Array.isArray(body.blocks) && body.blocks.length > 0,
+  },
+  {
+    name: 'toncenter v2 getMasterchainInfo',
+    url:  'https://toncenter.com/api/v2/getMasterchainInfo',
+    healthy: (r, body) => r.status === 200 && body.ok === true,
+  },
+  {
+    name: 'tonapi.io /v2/status',
+    url:  'https://tonapi.io/v2/status',
+    healthy: (r, body) => r.status === 200 && body.indexing === true,
+  },
+];
+
+async function probe(p) {
+  const t0 = Date.now();
+  try {
+    const r = await fetch(p.url, {
+      headers: { 'Accept': 'application/json' },
+      signal: AbortSignal.timeout(8000),
+    });
+    const elapsed = Date.now() - t0;
+    let body = null;
+    try { body = await r.json(); } catch { /* not JSON */ }
+    const ok = body !== null && p.healthy(r, body);
+    return { name: p.name, url: p.url, status: r.status, elapsed_ms: elapsed, healthy: ok };
+  } catch (e) {
+    return { name: p.name, url: p.url, status: 0, elapsed_ms: Date.now() - t0, healthy: false, error: e.message };
+  }
+}
+
+(async () => {
+  const results = await Promise.all(PROVIDERS.map(probe));
+  const asJSON = process.argv.includes('--json');
+  if (asJSON) {
+    console.log(JSON.stringify(results, null, 2));
+  } else {
+    for (const r of results) {
+      const tag = r.healthy ? '✓' : '✗';
+      const line = `${tag}  ${r.name.padEnd(38)}  HTTP ${String(r.status).padEnd(3)}  ${r.elapsed_ms}ms`;
+      console.log(r.error ? `${line}  (${r.error})` : line);
+    }
+  }
+  const anyHealthy = results.some(r => r.healthy);
+  process.exit(anyHealthy ? 0 : 1);
+})();


### PR DESCRIPTION
Compares 4 public TON RPC providers (toncenter v2 / v3, TonAPI, dton) and recommends toncenter v3 /blocks for the TPS-tracker MVP because its tx_count field gives us per-block transaction counts in a single call.

- docs/ton-rpc-endpoints.md — full provider matrix, endpoint shapes for the three viable TPS-measurement strategies (REST / indexed / raw lite-server), and the rationale for picking toncenter v3.
- scripts/probe-ton-rpc.js — zero-dep Node 18+ connectivity smoke test that pings the three production endpoints and reports status + latency. Exits 0 iff any provider responded healthy, so it can be wired into CI.

Verifies:
  node scripts/probe-ton-rpc.js → toncenter v3, toncenter v2, tonapi.io all 200 OK in <500ms.

Closes T02.