### PR TITLE
Create TON TPS calculation hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "node scripts/test-tps-utils.js",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/scripts/test-tps-utils.js
+++ b/scripts/test-tps-utils.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict'
+
+import {
+  calculateTps,
+  normalizeToncenterBlocks,
+  retryDelay,
+} from '../src/utils/tps.js'
+
+const blocks = [
+  { seqno: 3, gen_utime: 130, tx_count: 40 },
+  { seqno: 1, gen_utime: 100, tx_count: 20 },
+  { seqno: 2, gen_utime: 115, tx_count: 30 },
+]
+
+assert.deepEqual(calculateTps(blocks), {
+  tps: 3,
+  totalTransactions: 90,
+  windowSeconds: 30,
+  sampleCount: 3,
+})
+
+assert.deepEqual(normalizeToncenterBlocks({ blocks: [{ seqno: 4, gen_utime: 140, tx_count: 10 }] }), [
+  { seqno: 4, timestamp: 140, txCount: 10 },
+])
+
+assert.equal(retryDelay(0), 1000)
+assert.equal(retryDelay(3), 8000)
+assert.equal(retryDelay(10), 15000)
+
+console.log('tps utility tests passed')

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,33 @@
 import Header from './components/Header.jsx'
+import { useTonTps } from './hooks/useTonTps.js'
 
 export default function App() {
+  const ton = useTonTps()
+
   return (
     <div>
       <Header />
-      <main>
-        <p>Real-time TON blockchain TPS dashboard. UI coming in T02+.</p>
+      <main className="dashboard">
+        <section className="tps-card">
+          <p className="eyebrow">Live TON throughput</p>
+          <strong className="tps-value">{ton.status === 'ready' ? ton.tps : '...'}</strong>
+          <span className="tps-label">transactions / second</span>
+          <p className={`status ${ton.status}`}>{ton.error || ton.status}</p>
+        </section>
+        <section className="meta-grid">
+          <div>
+            <span>Total tx sampled</span>
+            <strong>{ton.totalTransactions}</strong>
+          </div>
+          <div>
+            <span>Window</span>
+            <strong>{ton.windowSeconds}s</strong>
+          </div>
+          <div>
+            <span>Blocks</span>
+            <strong>{ton.sampleCount}</strong>
+          </div>
+        </section>
       </main>
     </div>
   )

--- a/src/hooks/useTonTps.js
+++ b/src/hooks/useTonTps.js
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { calculateTps, normalizeToncenterBlocks, retryDelay } from '../utils/tps.js'
+
+const DEFAULT_ENDPOINT = 'https://toncenter.com/api/v3/blocks?workchain=-1&limit=12'
+
+export function useTonTps({
+  endpoint = DEFAULT_ENDPOINT,
+  intervalMs = 5000,
+  fetcher = fetch,
+} = {}) {
+  const [state, setState] = useState({
+    status: 'loading',
+    tps: 0,
+    totalTransactions: 0,
+    windowSeconds: 0,
+    sampleCount: 0,
+    error: null,
+    updatedAt: null,
+  })
+  const attemptRef = useRef(0)
+  const timerRef = useRef(null)
+  const cancelledRef = useRef(false)
+
+  const load = useCallback(async () => {
+    try {
+      const response = await fetcher(endpoint, {
+        headers: { Accept: 'application/json' },
+      })
+      if (!response.ok) {
+        throw new Error(`TON RPC returned HTTP ${response.status}`)
+      }
+      const body = await response.json()
+      const result = calculateTps(normalizeToncenterBlocks(body))
+      attemptRef.current = 0
+      if (!cancelledRef.current) {
+        setState({
+          status: 'ready',
+          error: null,
+          updatedAt: new Date().toISOString(),
+          ...result,
+        })
+      }
+    } catch (error) {
+      const attempt = attemptRef.current
+      attemptRef.current += 1
+      if (!cancelledRef.current) {
+        setState((current) => ({
+          ...current,
+          status: 'error',
+          error: error.message,
+        }))
+      }
+      window.clearTimeout(timerRef.current)
+      timerRef.current = window.setTimeout(load, retryDelay(attempt))
+    }
+  }, [endpoint, fetcher])
+
+  useEffect(() => {
+    cancelledRef.current = false
+    load()
+    const interval = window.setInterval(load, intervalMs)
+    return () => {
+      cancelledRef.current = true
+      window.clearInterval(interval)
+      window.clearTimeout(timerRef.current)
+    }
+  }, [intervalMs, load])
+
+  return state
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,57 @@
 * { box-sizing: border-box; }
-body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, sans-serif; }
-header { padding: 1rem 1.5rem; border-bottom: 1px solid #eee; }
-main { padding: 1.5rem; }
+body {
+  margin: 0;
+  background: #07111f;
+  color: #edf6ff;
+  font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+}
+header {
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid rgba(125, 211, 252, 0.2);
+}
+.dashboard {
+  display: grid;
+  gap: 1rem;
+  max-width: 860px;
+  padding: 1.5rem;
+}
+.tps-card {
+  border: 1px solid rgba(45, 212, 191, 0.36);
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(14, 116, 144, 0.25));
+  padding: 1.5rem;
+}
+.eyebrow,
+.tps-label,
+.meta-grid span {
+  color: #93c5fd;
+}
+.tps-value {
+  display: block;
+  color: #67e8f9;
+  font-size: clamp(3rem, 14vw, 7rem);
+  line-height: 1;
+}
+.status {
+  color: #a7f3d0;
+  min-height: 1.4em;
+}
+.status.error { color: #fca5a5; }
+.meta-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+.meta-grid div {
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 12px;
+  padding: 1rem;
+}
+.meta-grid strong {
+  display: block;
+  font-size: 1.4rem;
+  margin-top: 0.35rem;
+}
+@media (max-width: 620px) {
+  .meta-grid { grid-template-columns: 1fr; }
+}

--- a/src/utils/tps.js
+++ b/src/utils/tps.js
@@ -1,0 +1,46 @@
+export function calculateTps(blocks = []) {
+  const usable = blocks
+    .map(normalizeBlock)
+    .filter((block) => Number.isFinite(block.timestamp) && Number.isFinite(block.txCount))
+    .sort((a, b) => a.timestamp - b.timestamp);
+
+  if (usable.length < 2) {
+    return {
+      tps: 0,
+      totalTransactions: usable[0]?.txCount || 0,
+      windowSeconds: 0,
+      sampleCount: usable.length,
+    };
+  }
+
+  const first = usable[0];
+  const last = usable[usable.length - 1];
+  const windowSeconds = Math.max(1, last.timestamp - first.timestamp);
+  const totalTransactions = usable.reduce((sum, block) => sum + block.txCount, 0);
+
+  return {
+    tps: Number((totalTransactions / windowSeconds).toFixed(2)),
+    totalTransactions,
+    windowSeconds,
+    sampleCount: usable.length,
+  };
+}
+
+export function normalizeToncenterBlocks(payload) {
+  if (!payload) return [];
+  const blocks = Array.isArray(payload.blocks) ? payload.blocks : payload.result || [];
+  return blocks.map(normalizeBlock);
+}
+
+export function retryDelay(attempt, baseMs = 1000, maxMs = 15000) {
+  const safeAttempt = Math.max(0, Number(attempt) || 0);
+  return Math.min(maxMs, baseMs * (2 ** safeAttempt));
+}
+
+function normalizeBlock(block) {
+  return {
+    seqno: Number(block.seqno ?? block.seq_no ?? block.id?.seqno ?? 0),
+    timestamp: Number(block.gen_utime ?? block.utime ?? block.timestamp),
+    txCount: Number(block.tx_count ?? block.transactions_count ?? block.txCount ?? 0),
+  };
+}


### PR DESCRIPTION
## Summary
/claim #3
Closes #3

- add a mockable `useTonTps` React hook backed by toncenter v3 `/blocks` data
- calculate rolling TPS from block timestamps and transaction counts with retry/backoff handling
- render the live TPS, sample window, sampled transaction count, block count, loading state, and API error state
- add Node utility tests for TPS calculation, toncenter payload normalization, and retry delay bounds

## Verification
- npm test
- npm run build
- git diff --check
- node scripts/probe-ton-rpc.js --json (toncenter v3 and v2 healthy during probe)
- Chrome headless smoke on Vite dev server; screenshot written to /tmp/ton-tps-hook-desktop.png and DOM showed throughput card/error retry state

## Disclosure
Implemented with Codex assistance and manually verified before submission.