### PR TITLE
Build main TPS display component

### DIFF
--- a/scripts/test-tps-utils.js
+++ b/scripts/test-tps-utils.js
@@ -6,6 +6,7 @@ import {
   normalizeToncenterBlocks,
   retryDelay,
 } from '../src/utils/tps.js'
+import { connectionStatus, formatTps } from '../src/utils/displayState.js'
 
 const blocks = [
   { seqno: 3, gen_utime: 130, tx_count: 40 },
@@ -27,5 +28,15 @@ assert.deepEqual(normalizeToncenterBlocks({ blocks: [{ seqno: 4, gen_utime: 140,
 assert.equal(retryDelay(0), 1000)
 assert.equal(retryDelay(3), 8000)
 assert.equal(retryDelay(10), 15000)
+
+assert.equal(formatTps(1234.567), '1,234.57')
+assert.equal(formatTps(Number.NaN), '...')
+assert.deepEqual(connectionStatus({ status: 'loading' }), {
+  tone: 'loading',
+  label: 'Connecting to TON RPC',
+  detail: 'Fetching latest blocks',
+})
+assert.equal(connectionStatus({ status: 'error', error: 'HTTP 429' }).label, 'RPC retrying')
+assert.equal(connectionStatus({ status: 'ready', updatedAt: '2026-05-12T19:30:00Z' }).tone, 'ready')
 
 console.log('tps utility tests passed')

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import Header from './components/Header.jsx'
+import TpsDisplay from './components/TpsDisplay.jsx'
 import { useTonTps } from './hooks/useTonTps.js'
 
 export default function App() {
@@ -8,26 +9,7 @@ export default function App() {
     <div>
       <Header />
       <main className="dashboard">
-        <section className="tps-card">
-          <p className="eyebrow">Live TON throughput</p>
-          <strong className="tps-value">{ton.status === 'ready' ? ton.tps : '...'}</strong>
-          <span className="tps-label">transactions / second</span>
-          <p className={`status ${ton.status}`}>{ton.error || ton.status}</p>
-        </section>
-        <section className="meta-grid">
-          <div>
-            <span>Total tx sampled</span>
-            <strong>{ton.totalTransactions}</strong>
-          </div>
-          <div>
-            <span>Window</span>
-            <strong>{ton.windowSeconds}s</strong>
-          </div>
-          <div>
-            <span>Blocks</span>
-            <strong>{ton.sampleCount}</strong>
-          </div>
-        </section>
+        <TpsDisplay {...ton} />
       </main>
     </div>
   )

--- a/src/components/TpsDisplay.jsx
+++ b/src/components/TpsDisplay.jsx
@@ -1,0 +1,42 @@
+import { connectionStatus, formatTps } from '../utils/displayState.js'
+
+export default function TpsDisplay({
+  status,
+  tps,
+  totalTransactions,
+  windowSeconds,
+  sampleCount,
+  error,
+  updatedAt,
+}) {
+  const connection = connectionStatus({ status, error, updatedAt })
+
+  return (
+    <section className={`tps-card ${connection.tone}`} aria-live="polite">
+      <div className="card-header">
+        <p className="eyebrow">Live TON throughput</p>
+        <span className={`connection-dot ${connection.tone}`} />
+      </div>
+      <strong className="tps-value">{formatTps(status === 'ready' ? tps : Number.NaN)}</strong>
+      <span className="tps-label">transactions / second</span>
+      <p className={`status ${connection.tone}`}>
+        <span>{connection.label}</span>
+        <small>{connection.detail}</small>
+      </p>
+      <div className="meta-grid">
+        <div>
+          <span>Total tx sampled</span>
+          <strong>{totalTransactions}</strong>
+        </div>
+        <div>
+          <span>Window</span>
+          <strong>{windowSeconds}s</strong>
+        </div>
+        <div>
+          <span>Blocks</span>
+          <strong>{sampleCount}</strong>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -21,6 +21,23 @@ header {
   background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(14, 116, 144, 0.25));
   padding: 1.5rem;
 }
+.tps-card.error { border-color: rgba(248, 113, 113, 0.5); }
+.tps-card.loading { border-color: rgba(147, 197, 253, 0.4); }
+.card-header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.connection-dot {
+  border-radius: 999px;
+  display: inline-block;
+  height: 0.75rem;
+  width: 0.75rem;
+}
+.connection-dot.ready { background: #34d399; box-shadow: 0 0 16px rgba(52, 211, 153, 0.75); }
+.connection-dot.error { background: #f87171; box-shadow: 0 0 16px rgba(248, 113, 113, 0.7); }
+.connection-dot.loading { background: #93c5fd; box-shadow: 0 0 16px rgba(147, 197, 253, 0.65); }
 .eyebrow,
 .tps-label,
 .meta-grid span {
@@ -34,9 +51,16 @@ header {
 }
 .status {
   color: #a7f3d0;
+  display: grid;
+  gap: 0.25rem;
   min-height: 1.4em;
 }
 .status.error { color: #fca5a5; }
+.status.loading { color: #bfdbfe; }
+.status small {
+  color: #94a3b8;
+  font-size: 0.82rem;
+}
 .meta-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/src/utils/displayState.js
+++ b/src/utils/displayState.js
@@ -1,0 +1,24 @@
+export function connectionStatus({ status, error, updatedAt } = {}) {
+  if (status === 'loading') {
+    return { tone: 'loading', label: 'Connecting to TON RPC', detail: 'Fetching latest blocks' }
+  }
+  if (status === 'error') {
+    return { tone: 'error', label: 'RPC retrying', detail: error || 'Temporary TON RPC error' }
+  }
+  if (status === 'ready') {
+    return {
+      tone: 'ready',
+      label: 'Live connection',
+      detail: updatedAt ? `Updated ${new Date(updatedAt).toLocaleTimeString()}` : 'Blocks received',
+    }
+  }
+  return { tone: 'idle', label: 'Waiting', detail: 'No connection attempt yet' }
+}
+
+export function formatTps(value) {
+  if (!Number.isFinite(Number(value))) return '...'
+  return Number(value).toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: Number(value) % 1 === 0 ? 0 : 2,
+  })
+}


### PR DESCRIPTION
## Summary
/claim #4
Closes #4

- extract the primary TPS display into a reusable `TpsDisplay` component
- add large readable TPS output, sampled transaction/window/block metadata, loading state, error retry state, and connection status indicator
- add display-state utilities and Node assertions for formatting and connection state mapping

## Verification
- npm test
- npm run build
- git diff --check
- Chrome headless smoke on Vite dev server; screenshot written to /tmp/ton-tps-display-desktop.png and DOM confirmed connection indicator plus error/loading-ready copy paths

## Disclosure
Implemented with Codex assistance and manually verified before submission.