### PR TITLE
feat: [T05] implement TPS history chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "chart.js": "^4.4.6",
     "react": "^18.3.1",
+    "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {

--- a/scripts/test-tps-utils.js
+++ b/scripts/test-tps-utils.js
@@ -7,6 +7,7 @@ import {
   retryDelay,
 } from '../src/utils/tps.js'
 import { connectionStatus, formatTps } from '../src/utils/displayState.js'
+import { appendSample, DEFAULT_WINDOW_SECONDS } from '../src/utils/tpsHistory.js'
 
 const blocks = [
   { seqno: 3, gen_utime: 130, tx_count: 40 },
@@ -38,5 +39,37 @@ assert.deepEqual(connectionStatus({ status: 'loading' }), {
 })
 assert.equal(connectionStatus({ status: 'error', error: 'HTTP 429' }).label, 'RPC retrying')
 assert.equal(connectionStatus({ status: 'ready', updatedAt: '2026-05-12T19:30:00Z' }).tone, 'ready')
+
+// tpsHistory.appendSample
+assert.equal(DEFAULT_WINDOW_SECONDS, 60)
+
+const t0 = 1_700_000_000_000
+const h1 = appendSample([], { ts: t0, tps: 5 })
+assert.deepEqual(h1, [{ ts: t0, tps: 5 }])
+
+const h2 = appendSample(h1, { ts: t0 + 5000, tps: 6 })
+assert.deepEqual(h2, [
+  { ts: t0, tps: 5 },
+  { ts: t0 + 5000, tps: 6 },
+])
+
+// drops samples outside the window
+const h3 = appendSample(h2, { ts: t0 + 65000, tps: 7 }, 60)
+assert.deepEqual(h3, [
+  { ts: t0 + 5000, tps: 6 },
+  { ts: t0 + 65000, tps: 7 },
+])
+
+// dedupes by timestamp (replaces with latest)
+const h4 = appendSample(h2, { ts: t0 + 5000, tps: 9 })
+assert.deepEqual(h4, [
+  { ts: t0, tps: 5 },
+  { ts: t0 + 5000, tps: 9 },
+])
+
+// ignores invalid samples
+assert.equal(appendSample(h1, null), h1)
+assert.equal(appendSample(h1, { ts: Number.NaN, tps: 1 }), h1)
+assert.equal(appendSample(h1, { ts: t0, tps: Number.NaN }), h1)
 
 console.log('tps utility tests passed')

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,15 +1,19 @@
 import Header from './components/Header.jsx'
 import TpsDisplay from './components/TpsDisplay.jsx'
+import TpsHistoryChart from './components/TpsHistoryChart.jsx'
 import { useTonTps } from './hooks/useTonTps.js'
+import { useTpsHistory } from './hooks/useTpsHistory.js'
 
 export default function App() {
   const ton = useTonTps()
+  const history = useTpsHistory(ton)
 
   return (
     <div>
       <Header />
       <main className="dashboard">
         <TpsDisplay {...ton} />
+        <TpsHistoryChart history={history} />
       </main>
     </div>
   )

--- a/src/components/TpsHistoryChart.jsx
+++ b/src/components/TpsHistoryChart.jsx
@@ -1,0 +1,104 @@
+import { useMemo, useRef } from 'react'
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  Filler,
+  LineElement,
+  LinearScale,
+  PointElement,
+  Tooltip,
+} from 'chart.js'
+import { Line } from 'react-chartjs-2'
+import { DEFAULT_WINDOW_SECONDS } from '../utils/tpsHistory.js'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Filler, Tooltip)
+
+const ACCENT = '#67e8f9'
+const ACCENT_SOFT = 'rgba(103, 232, 249, 0.18)'
+const GRID = 'rgba(148, 163, 184, 0.18)'
+const AXIS_LABEL = '#93c5fd'
+
+function formatOffset(seconds) {
+  if (seconds === 0) return 'now'
+  return `-${seconds}s`
+}
+
+export default function TpsHistoryChart({ history, windowSeconds = DEFAULT_WINDOW_SECONDS }) {
+  const chartRef = useRef(null)
+
+  const data = useMemo(() => {
+    const now = history.length ? history[history.length - 1].ts : Date.now()
+    const labels = history.map((entry) => formatOffset(Math.round((now - entry.ts) / 1000)))
+    return {
+      labels,
+      datasets: [
+        {
+          label: 'TPS',
+          data: history.map((entry) => entry.tps),
+          borderColor: ACCENT,
+          backgroundColor: ACCENT_SOFT,
+          borderWidth: 2,
+          fill: true,
+          tension: 0.35,
+          pointRadius: history.length > 24 ? 0 : 3,
+          pointBackgroundColor: ACCENT,
+          pointBorderColor: ACCENT,
+        },
+      ],
+    }
+  }, [history])
+
+  const options = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: { duration: 250 },
+      interaction: { mode: 'nearest', intersect: false },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: 'rgba(7, 17, 31, 0.92)',
+          borderColor: 'rgba(45, 212, 191, 0.4)',
+          borderWidth: 1,
+          titleColor: AXIS_LABEL,
+          bodyColor: '#edf6ff',
+          callbacks: {
+            label: (ctx) => `${ctx.parsed.y.toLocaleString(undefined, { maximumFractionDigits: 2 })} tx/s`,
+          },
+        },
+      },
+      scales: {
+        x: {
+          grid: { color: GRID, drawTicks: false },
+          ticks: { color: AXIS_LABEL, maxRotation: 0, autoSkipPadding: 16 },
+          border: { display: false },
+        },
+        y: {
+          beginAtZero: true,
+          grid: { color: GRID, drawTicks: false },
+          ticks: { color: AXIS_LABEL, precision: 0 },
+          border: { display: false },
+        },
+      },
+    }),
+    [],
+  )
+
+  const isEmpty = history.length === 0
+
+  return (
+    <section className="tps-chart-card" aria-label={`TPS over the last ${windowSeconds} seconds`}>
+      <div className="card-header">
+        <p className="eyebrow">History · last {windowSeconds}s</p>
+        <span className="chart-sample-count">{history.length} sample{history.length === 1 ? '' : 's'}</span>
+      </div>
+      <div className="chart-canvas">
+        {isEmpty ? (
+          <p className="chart-empty">Collecting samples…</p>
+        ) : (
+          <Line ref={chartRef} data={data} options={options} />
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/hooks/useTpsHistory.js
+++ b/src/hooks/useTpsHistory.js
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react'
+import { appendSample, DEFAULT_WINDOW_SECONDS } from '../utils/tpsHistory.js'
+
+export function useTpsHistory({ status, tps, updatedAt }, windowSeconds = DEFAULT_WINDOW_SECONDS) {
+  const [history, setHistory] = useState([])
+
+  useEffect(() => {
+    if (status !== 'ready' || !updatedAt) return
+    const ts = Date.parse(updatedAt)
+    if (!Number.isFinite(ts)) return
+    setHistory((prev) => appendSample(prev, { ts, tps }, windowSeconds, ts))
+  }, [status, tps, updatedAt, windowSeconds])
+
+  return history
+}

--- a/src/index.css
+++ b/src/index.css
@@ -76,6 +76,34 @@ header {
   font-size: 1.4rem;
   margin-top: 0.35rem;
 }
+.tps-chart-card {
+  border: 1px solid rgba(45, 212, 191, 0.36);
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(14, 116, 144, 0.18));
+  padding: 1.25rem 1.5rem 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+.chart-sample-count {
+  color: #93c5fd;
+  font-size: 0.82rem;
+}
+.chart-canvas {
+  position: relative;
+  height: clamp(200px, 32vw, 280px);
+  width: 100%;
+}
+.chart-empty {
+  color: #94a3b8;
+  font-size: 0.95rem;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
 @media (max-width: 620px) {
   .meta-grid { grid-template-columns: 1fr; }
+  .tps-chart-card { padding: 1rem; }
+  .chart-canvas { height: clamp(180px, 56vw, 240px); }
 }

--- a/src/utils/tpsHistory.js
+++ b/src/utils/tpsHistory.js
@@ -1,0 +1,12 @@
+export const DEFAULT_WINDOW_SECONDS = 60
+
+export function appendSample(history, sample, windowSeconds = DEFAULT_WINDOW_SECONDS, now = sample?.ts) {
+  if (!sample || !Number.isFinite(sample.ts) || !Number.isFinite(sample.tps)) {
+    return history
+  }
+  const cutoff = now - windowSeconds * 1000
+  const next = history.filter((entry) => entry.ts >= cutoff && entry.ts !== sample.ts)
+  next.push(sample)
+  next.sort((a, b) => a.ts - b.ts)
+  return next
+}


### PR DESCRIPTION
## Summary

Implements **T05 — Implement TPS history chart** (Closes #5).

- Adds `chart.js` + `react-chartjs-2` and a new `TpsHistoryChart` component rendering a line chart of TPS over the last 60 seconds.
- New `useTpsHistory` hook accumulates samples from `useTonTps` whenever `updatedAt` advances, and trims entries outside the rolling window.
- Pure `appendSample` util (in `src/utils/tpsHistory.js`) is unit-tested in `scripts/test-tps-utils.js`.
- Styling matches the existing dark/teal `.tps-card` aesthetic; the chart is responsive (mobile-friendly height + reduced point markers as the series fills in).

## Test plan

- [x] `npm test` — passes (existing + new `tpsHistory` cases)
- [x] `npm run build` — passes (303 kB bundle, 102 kB gzipped)
- [x] Manual: dev server renders chart card under the main TPS counter, "Collecting samples…" empty state shows before first poll, line builds up as samples arrive, last 60s window is honored

## Notes

- Reused the existing `useTonTps` polling cadence (5s) — no new network traffic.
- Did not commit `package-lock.json` (the repo doesn't ship one).