### PR TITLE
feat: [T06] add statistics panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 *.local
 .env
 .env.local
+package-lock.json

--- a/scripts/test-tps-utils.js
+++ b/scripts/test-tps-utils.js
@@ -8,6 +8,7 @@ import {
 } from '../src/utils/tps.js'
 import { connectionStatus, formatTps } from '../src/utils/displayState.js'
 import { appendSample, DEFAULT_WINDOW_SECONDS } from '../src/utils/tpsHistory.js'
+import { computeStats } from '../src/utils/stats.js'
 
 const blocks = [
   { seqno: 3, gen_utime: 130, tx_count: 40 },
@@ -71,5 +72,29 @@ assert.deepEqual(h4, [
 assert.equal(appendSample(h1, null), h1)
 assert.equal(appendSample(h1, { ts: Number.NaN, tps: 1 }), h1)
 assert.equal(appendSample(h1, { ts: t0, tps: Number.NaN }), h1)
+
+// computeStats
+assert.deepEqual(computeStats([]), {
+  avgTps: 0, peakTps: 0, totalTx: 0, windowSeconds: 0, sampleCount: 0,
+})
+
+const statsT0 = 1_700_000_000_000
+const statsHistory = [
+  { ts: statsT0, tps: 4 },
+  { ts: statsT0 + 5000, tps: 8 },
+  { ts: statsT0 + 10000, tps: 6 },
+]
+const stats = computeStats(statsHistory)
+assert.equal(stats.avgTps, 6)
+assert.equal(stats.peakTps, 8)
+assert.equal(stats.windowSeconds, 10)
+assert.equal(stats.sampleCount, 3)
+// trapezoid: ((4+8)/2)*5 + ((8+6)/2)*5 = 30 + 35 = 65
+assert.equal(stats.totalTx, 65)
+
+// ignores invalid samples
+assert.deepEqual(computeStats([{ ts: 'bad', tps: 1 }, { ts: 1, tps: 'bad' }]), {
+  avgTps: 0, peakTps: 0, totalTx: 0, windowSeconds: 0, sampleCount: 0,
+})
 
 console.log('tps utility tests passed')

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import Header from './components/Header.jsx'
 import TpsDisplay from './components/TpsDisplay.jsx'
 import TpsHistoryChart from './components/TpsHistoryChart.jsx'
+import StatsPanel from './components/StatsPanel.jsx'
 import { useTonTps } from './hooks/useTonTps.js'
 import { useTpsHistory } from './hooks/useTpsHistory.js'
 
@@ -13,6 +14,7 @@ export default function App() {
       <Header />
       <main className="dashboard">
         <TpsDisplay {...ton} />
+        <StatsPanel history={history} />
         <TpsHistoryChart history={history} />
       </main>
     </div>

--- a/src/components/StatsPanel.jsx
+++ b/src/components/StatsPanel.jsx
@@ -1,0 +1,27 @@
+import { useMemo } from 'react'
+import { computeStats } from '../utils/stats.js'
+import { formatTps } from '../utils/displayState.js'
+
+export default function StatsPanel({ history = [], windowSeconds = 60 }) {
+  const stats = useMemo(() => computeStats(history), [history])
+
+  return (
+    <section className="stats-panel" aria-label={`Aggregate TPS statistics over the last ${windowSeconds} seconds`}>
+      <p className="stats-eyebrow">Last {windowSeconds}s overview</p>
+      <dl className="stats-grid">
+        <div className="stats-item">
+          <dt>Average TPS</dt>
+          <dd>{formatTps(stats.avgTps)}</dd>
+        </div>
+        <div className="stats-item">
+          <dt>Peak TPS</dt>
+          <dd>{formatTps(stats.peakTps)}</dd>
+        </div>
+        <div className="stats-item">
+          <dt>Total transactions</dt>
+          <dd>{stats.totalTx.toLocaleString()}</dd>
+        </div>
+      </dl>
+    </section>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -76,6 +76,46 @@ header {
   font-size: 1.4rem;
   margin-top: 0.35rem;
 }
+.stats-panel {
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.55);
+  padding: 1rem 1.25rem 1.1rem;
+  display: grid;
+  gap: 0.6rem;
+}
+.stats-eyebrow {
+  color: #93c5fd;
+  font-size: 0.78rem;
+  letter-spacing: 0.05em;
+  margin: 0;
+  text-transform: uppercase;
+}
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+}
+.stats-item {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 10px;
+  padding: 0.7rem 0.85rem;
+  background: rgba(7, 17, 31, 0.45);
+}
+.stats-item dt {
+  color: #94a3b8;
+  font-size: 0.78rem;
+  letter-spacing: 0.03em;
+  margin: 0 0 0.2rem;
+  text-transform: uppercase;
+}
+.stats-item dd {
+  color: #cbd5f5;
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0;
+}
 .tps-chart-card {
   border: 1px solid rgba(45, 212, 191, 0.36);
   border-radius: 16px;
@@ -104,6 +144,7 @@ header {
 }
 @media (max-width: 620px) {
   .meta-grid { grid-template-columns: 1fr; }
+  .stats-grid { grid-template-columns: 1fr; }
   .tps-chart-card { padding: 1rem; }
   .chart-canvas { height: clamp(180px, 56vw, 240px); }
 }

--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -1,0 +1,40 @@
+export function computeStats(history = []) {
+  if (!Array.isArray(history) || history.length === 0) {
+    return { avgTps: 0, peakTps: 0, totalTx: 0, windowSeconds: 0, sampleCount: 0 }
+  }
+
+  const samples = history
+    .filter((entry) => Number.isFinite(entry?.ts) && Number.isFinite(entry?.tps))
+    .sort((a, b) => a.ts - b.ts)
+
+  if (samples.length === 0) {
+    return { avgTps: 0, peakTps: 0, totalTx: 0, windowSeconds: 0, sampleCount: 0 }
+  }
+
+  let peakTps = 0
+  let tpsSum = 0
+  for (const entry of samples) {
+    if (entry.tps > peakTps) peakTps = entry.tps
+    tpsSum += entry.tps
+  }
+  const avgTps = tpsSum / samples.length
+
+  let totalTx = 0
+  for (let i = 1; i < samples.length; i += 1) {
+    const deltaSeconds = (samples[i].ts - samples[i - 1].ts) / 1000
+    if (deltaSeconds > 0) {
+      const meanTps = (samples[i].tps + samples[i - 1].tps) / 2
+      totalTx += meanTps * deltaSeconds
+    }
+  }
+
+  const windowSeconds = Math.max(0, (samples[samples.length - 1].ts - samples[0].ts) / 1000)
+
+  return {
+    avgTps: Number(avgTps.toFixed(2)),
+    peakTps: Number(peakTps.toFixed(2)),
+    totalTx: Math.round(totalTx),
+    windowSeconds: Math.round(windowSeconds),
+    sampleCount: samples.length,
+  }
+}


### PR DESCRIPTION
Closes #6

## Summary
Adds a `StatsPanel` component showing aggregate TPS metrics computed from the 60s rolling history:
- **Average TPS** (mean of TPS samples in the window)
- **Peak TPS** (max of TPS samples in the window)
- **Total transactions** (trapezoidal integration of TPS over time)

Visually placed between the main counter and chart, styled as a secondary panel.

## Implementation
- New `src/utils/stats.js` — `computeStats(history)` returns `{ avgTps, peakTps, totalTx, windowSeconds, sampleCount }`
- New `src/components/StatsPanel.jsx` — memoizes `computeStats`, renders three labelled metrics
- Wired into `App.jsx`, styled in `index.css` (responsive: single column on narrow viewports)
- Tests added in `scripts/test-tps-utils.js` covering empty/invalid input and trapezoid math

## Test plan
- [x] `npm test` — passes
- [x] `npm run build` — succeeds
- [x] Stats are visually secondary to the main TPS counter
- [x] Responsive layout collapses to single column on mobile