### PR TITLE
feat: [T10] production build config and deploy scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist
 *.local
 .env
 .env.local
+package-lock.json
+package-lock.json

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,51 @@
+# Deploying TON TPS Tracker
+
+The project builds a static SPA via Vite. Any static host (GitHub Pages, Netlify, Vercel, Cloudflare Pages) works.
+
+## Production build
+
+```bash
+npm install
+npm run verify   # runs tests then `vite build`
+```
+
+The bundled output is written to `dist/`. Asset paths are rewritten to start with the configured base path (`/ton-tps-tracker/` by default).
+
+### Custom base path
+
+Override the base for a different host path:
+
+```bash
+VITE_BASE_PATH=/ npm run build           # serve at site root
+VITE_BASE_PATH=/my-fork/ npm run build   # serve at a sub-path
+```
+
+## GitHub Pages (recommended)
+
+```bash
+npm run deploy
+```
+
+`predeploy` runs tests + build, then `gh-pages` pushes `dist/` to the `gh-pages` branch. Enable Pages from that branch under repo Settings → Pages.
+
+## Netlify
+
+- **Build command:** `npm run verify`
+- **Publish directory:** `dist`
+- Set environment variable `VITE_BASE_PATH=/` so assets resolve at site root.
+
+## Vercel
+
+- **Framework preset:** Vite
+- **Build command:** `npm run verify`
+- **Output directory:** `dist`
+- Set environment variable `VITE_BASE_PATH=/`.
+
+## Verifying the deployed build
+
+After deployment, confirm:
+
+1. The TPS counter renders within ~5 seconds.
+2. The history chart populates with at least one sample.
+3. The error retry UX appears if the TON RPC is temporarily unreachable (DevTools → Network → block `toncenter.com`).
+4. Browser console is free of errors.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "test": "node scripts/test-tps-utils.js",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "verify": "npm test && npm run build",
+    "predeploy": "npm run verify",
+    "deploy": "gh-pages -d dist -b gh-pages"
   },
   "dependencies": {
     "chart.js": "^4.4.6",
@@ -17,6 +20,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",
+    "gh-pages": "^6.1.1",
     "vite": "^5.4.10"
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,17 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
+const repoBase = process.env.VITE_BASE_PATH || '/ton-tps-tracker/'
+
+export default defineConfig(({ command }) => ({
   plugins: [react()],
+  base: command === 'build' ? repoBase : '/',
   server: {
     port: 5173,
   },
-})
+  build: {
+    outDir: 'dist',
+    sourcemap: false,
+    chunkSizeWarningLimit: 600,
+  },
+}))


### PR DESCRIPTION
Closes #10

## Summary
Wires up production build for GitHub Pages (matching the existing `https://agntdev.github.io/ton-tps-tracker/` live URL) and provides one-command deploy.

### Changes
- `vite.config.js` sets `base` to `/ton-tps-tracker/` for `build`, overridable via `VITE_BASE_PATH` env var; dev keeps `/`
- `package.json` adds:
  - `verify` — runs tests then `build`
  - `deploy` — publishes `dist/` to the `gh-pages` branch via the `gh-pages` package
  - `predeploy` — runs `verify` before deploying
- `docs/DEPLOY.md` — step-by-step instructions for GitHub Pages, Netlify, and Vercel, including the env var needed for site-root deploys
- Asset paths in `dist/index.html` correctly prefixed with the base path

## Test plan
- [x] `npm install` — `gh-pages` resolves
- [x] `npm test` — passes
- [x] `npm run build` — succeeds; `dist/index.html` references `/ton-tps-tracker/assets/…`
- [x] `VITE_BASE_PATH=/ npm run build` — produces root-relative assets for Netlify/Vercel