### PR TITLE
feat: [T10] Vercel/Netlify configs, deploy scripts, and build verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist
 *.local
 .env
 .env.local
+package-lock.json
+package-lock.json

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,51 +1,76 @@
 # Deploying TON TPS Tracker
 
-The project builds a static SPA via Vite. Any static host (GitHub Pages, Netlify, Vercel, Cloudflare Pages) works.
+The project builds a static SPA via Vite. Any static host works; this repo ships drop-in configs for **Netlify** (`netlify.toml`) and **Vercel** (`vercel.json`), plus a `gh-pages` fallback.
 
 ## Production build
 
 ```bash
 npm install
-npm run verify   # runs tests then `vite build`
+npm run verify   # tests → vite build → static bundle assertions
 ```
 
-The bundled output is written to `dist/`. Asset paths are rewritten to start with the configured base path (`/ton-tps-tracker/` by default).
+`verify` runs:
+
+1. `npm test` — unit tests for TPS math, history aggregator, display state.
+2. `vite build` — produces `dist/`.
+3. `node scripts/verify-build.js` — asserts the bundle is well-formed (HTML mounts `#root`, JS/CSS chunks exist with sane sizes, TON RPC endpoint is reachable from the bundle).
+
+Asset paths are rewritten to the configured base path (`/ton-tps-tracker/` by default).
 
 ### Custom base path
 
-Override the base for a different host path:
-
 ```bash
-VITE_BASE_PATH=/ npm run build           # serve at site root
-VITE_BASE_PATH=/my-fork/ npm run build   # serve at a sub-path
+VITE_BASE_PATH=/ npm run build           # serve at site root (Vercel/Netlify default)
+VITE_BASE_PATH=/my-fork/ npm run build   # serve at a sub-path (e.g. GitHub Pages on a fork)
 ```
 
-## GitHub Pages (recommended)
+## Netlify
+
+Shipped config: `netlify.toml`.
+
+```bash
+npm run deploy:netlify
+```
+
+This runs `verify` first, then `netlify deploy --prod --dir=dist`. The config also handles SPA fallback so client-side refreshes land on `index.html`.
+
+For deploys triggered by Netlify on push, the build command is set automatically by `netlify.toml`:
+
+- **Build command:** `npm run verify`
+- **Publish directory:** `dist`
+- **Environment:** `NODE_VERSION=20`, `VITE_BASE_PATH=/`
+
+## Vercel
+
+Shipped config: `vercel.json`.
+
+```bash
+npm run deploy:vercel
+```
+
+This runs `verify` first, then `vercel --prod`. The config:
+
+- Selects the Vite framework preset.
+- Forces `VITE_BASE_PATH=/` so assets resolve at site root.
+- Adds a catch-all rewrite to `/index.html` for SPA routing.
+
+## GitHub Pages (fallback)
 
 ```bash
 npm run deploy
 ```
 
-`predeploy` runs tests + build, then `gh-pages` pushes `dist/` to the `gh-pages` branch. Enable Pages from that branch under repo Settings → Pages.
+`predeploy` runs `verify`; `deploy` pushes `dist/` to the `gh-pages` branch via the `gh-pages` package. The default `VITE_BASE_PATH=/ton-tps-tracker/` is correct for this org's Pages URL.
 
-## Netlify
+## Verifying the deployed version
 
-- **Build command:** `npm run verify`
-- **Publish directory:** `dist`
-- Set environment variable `VITE_BASE_PATH=/` so assets resolve at site root.
+After deploy, confirm:
 
-## Vercel
-
-- **Framework preset:** Vite
-- **Build command:** `npm run verify`
-- **Output directory:** `dist`
-- Set environment variable `VITE_BASE_PATH=/`.
-
-## Verifying the deployed build
-
-After deployment, confirm:
-
-1. The TPS counter renders within ~5 seconds.
+1. The TPS counter renders within ~5 seconds and shows a non-`...` value.
 2. The history chart populates with at least one sample.
-3. The error retry UX appears if the TON RPC is temporarily unreachable (DevTools → Network → block `toncenter.com`).
-4. Browser console is free of errors.
+3. Connection dot shows green ("Live connection") in normal conditions.
+4. The error retry UX appears when the TON RPC is unreachable (DevTools → Network → block `toncenter.com`).
+5. Browser console is free of errors.
+6. Lighthouse: PWA-style basics pass (HTTPS, viewport meta, no JS errors).
+
+`scripts/verify-build.js` runs locally to verify the build before upload; a deploy job's CI should fail loudly if `npm run verify` fails.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,51 @@
+# Deploying TON TPS Tracker
+
+The project builds a static SPA via Vite. Any static host (GitHub Pages, Netlify, Vercel, Cloudflare Pages) works.
+
+## Production build
+
+```bash
+npm install
+npm run verify   # runs tests then `vite build`
+```
+
+The bundled output is written to `dist/`. Asset paths are rewritten to start with the configured base path (`/ton-tps-tracker/` by default).
+
+### Custom base path
+
+Override the base for a different host path:
+
+```bash
+VITE_BASE_PATH=/ npm run build           # serve at site root
+VITE_BASE_PATH=/my-fork/ npm run build   # serve at a sub-path
+```
+
+## GitHub Pages (recommended)
+
+```bash
+npm run deploy
+```
+
+`predeploy` runs tests + build, then `gh-pages` pushes `dist/` to the `gh-pages` branch. Enable Pages from that branch under repo Settings → Pages.
+
+## Netlify
+
+- **Build command:** `npm run verify`
+- **Publish directory:** `dist`
+- Set environment variable `VITE_BASE_PATH=/` so assets resolve at site root.
+
+## Vercel
+
+- **Framework preset:** Vite
+- **Build command:** `npm run verify`
+- **Output directory:** `dist`
+- Set environment variable `VITE_BASE_PATH=/`.
+
+## Verifying the deployed build
+
+After deployment, confirm:
+
+1. The TPS counter renders within ~5 seconds.
+2. The history chart populates with at least one sample.
+3. The error retry UX appears if the TON RPC is temporarily unreachable (DevTools → Network → block `toncenter.com`).
+4. Browser console is free of errors.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+[build]
+  command = "npm run verify"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "20"
+  VITE_BASE_PATH = "/"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
     "test": "node scripts/test-tps-utils.js",
     "build": "vite build",
     "preview": "vite preview",
-    "verify": "npm test && npm run build",
+    "verify": "npm test && npm run build && node scripts/verify-build.js",
     "predeploy": "npm run verify",
-    "deploy": "gh-pages -d dist -b gh-pages"
+    "deploy": "gh-pages -d dist -b gh-pages",
+    "deploy:vercel": "npm run verify && vercel --prod",
+    "deploy:netlify": "npm run verify && netlify deploy --prod --dir=dist"
   },
   "dependencies": {
     "chart.js": "^4.4.6",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "test": "node scripts/test-tps-utils.js",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "verify": "npm test && npm run build",
+    "predeploy": "npm run verify",
+    "deploy": "gh-pages -d dist -b gh-pages"
   },
   "dependencies": {
     "chart.js": "^4.4.6",
@@ -17,6 +20,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",
+    "gh-pages": "^6.1.1",
     "vite": "^5.4.10"
   }
 }

--- a/scripts/verify-build.js
+++ b/scripts/verify-build.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import assert from 'node:assert/strict'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const distDir = resolve(__dirname, '..', 'dist')
+
+function fail(message) {
+  console.error(`✗ ${message}`)
+  process.exit(1)
+}
+
+let indexHtml
+try {
+  indexHtml = readFileSync(resolve(distDir, 'index.html'), 'utf8')
+} catch (error) {
+  fail(`dist/index.html not found — run \`npm run build\` first (${error.message})`)
+}
+
+assert.match(indexHtml, /<div id="root">/, 'dist/index.html missing #root mount point')
+assert.match(indexHtml, /\.js"/, 'dist/index.html missing bundled script')
+assert.match(indexHtml, /\.css"/, 'dist/index.html missing bundled stylesheet')
+
+const assetsDir = resolve(distDir, 'assets')
+let assetFiles
+try {
+  assetFiles = readdirSync(assetsDir)
+} catch (error) {
+  fail(`dist/assets/ not found (${error.message})`)
+}
+
+const jsBundle = assetFiles.find((f) => f.endsWith('.js'))
+const cssBundle = assetFiles.find((f) => f.endsWith('.css'))
+assert.ok(jsBundle, 'dist/assets/ missing JS bundle')
+assert.ok(cssBundle, 'dist/assets/ missing CSS bundle')
+
+const jsStat = statSync(resolve(assetsDir, jsBundle))
+const cssStat = statSync(resolve(assetsDir, cssBundle))
+assert.ok(jsStat.size > 1024, `JS bundle suspiciously small: ${jsStat.size} bytes`)
+assert.ok(cssStat.size > 256, `CSS bundle suspiciously small: ${cssStat.size} bytes`)
+
+const jsContent = readFileSync(resolve(assetsDir, jsBundle), 'utf8')
+assert.match(jsContent, /toncenter\.com/, 'JS bundle missing TON RPC endpoint reference')
+
+console.log('✓ dist/index.html references bundled JS+CSS')
+console.log(`✓ JS bundle: ${jsBundle} (${jsStat.size} bytes)`)
+console.log(`✓ CSS bundle: ${cssBundle} (${cssStat.size} bytes)`)
+console.log('✓ Production build verified')

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "buildCommand": "npm run verify",
+  "outputDirectory": "dist",
+  "installCommand": "npm install",
+  "env": {
+    "VITE_BASE_PATH": "/"
+  },
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,17 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
+const repoBase = process.env.VITE_BASE_PATH || '/ton-tps-tracker/'
+
+export default defineConfig(({ command }) => ({
   plugins: [react()],
+  base: command === 'build' ? repoBase : '/',
   server: {
     port: 5173,
   },
-})
+  build: {
+    outDir: 'dist',
+    sourcemap: false,
+    chunkSizeWarningLimit: 600,
+  },
+}))


### PR DESCRIPTION
Closes #10

Replaces #22 (closed) — incorporates validator feedback.

## Summary
Adds **Vercel and Netlify deployment configurations** alongside an automated production-build verification step, plus a GitHub Pages fallback. Addresses the previous validation feedback:

- ✅ \`vercel.json\` — Vite framework preset, base path override, SPA rewrites
- ✅ \`netlify.toml\` — build command, publish dir, SPA redirects, Node 20
- ✅ \`scripts/verify-build.js\` — asserts \`dist/\` is well-formed (mount point, bundle sizes, TON RPC reference in JS), wired into \`npm run verify\`
- ✅ \`package.json\` scripts: \`deploy:vercel\` (\`vercel --prod\`), \`deploy:netlify\` (\`netlify deploy --prod --dir=dist\`), \`deploy\` (gh-pages fallback)
- ✅ \`docs/DEPLOY.md\` — complete deploy guide for all three targets and a post-deploy verification checklist

\`vite.config.js\` still drives the base path (\`VITE_BASE_PATH=/\` for Vercel/Netlify, \`/ton-tps-tracker/\` for the org's GitHub Pages URL).

## Test plan
- [x] \`npm run verify\` — tests + build + bundle assertions all pass
- [x] \`dist/index.html\` references hashed JS+CSS chunks
- [x] \`vercel.json\` validates against its JSON schema
- [x] \`netlify.toml\` parses cleanly